### PR TITLE
fix: update link for keplr download

### DIFF
--- a/web/src/components/KeplrLogin/index.tsx
+++ b/web/src/components/KeplrLogin/index.tsx
@@ -25,7 +25,7 @@ export default function Keplr(props: KeplrProps) {
 
       {/* Modal to install Keplr Chrome extension */}
       <Dialog onClose={handleClose} open={isOpen}>
-        <DialogTitle>Install Keplr Wallet Extension for Chrome</DialogTitle>
+        <DialogTitle>Please install Keplr Wallet Extension</DialogTitle>
         <List sx={{ pt: 0 }}>
           <ListItem>
             <ListItemAvatar>
@@ -34,10 +34,10 @@ export default function Keplr(props: KeplrProps) {
             <a
               className="ml-3"
               target="_blank"
-              href="https://chrome.google.com/webstore/detail/keplr/dmkamcknogkgcdfhhbddcghachkejeap"
+              href="https://www.keplr.app/download"
               onClick={handleClose}
             >
-              <ListItemText primary="View it in the Chrome Web Store" />
+              <ListItemText primary="Download Keplr extension" />
             </a>
           </ListItem>
         </List>


### PR DESCRIPTION
Updates the wording for the Keplr extension download link:

<img width="557" alt="image" src="https://user-images.githubusercontent.com/79639/218539228-aead41d4-be65-4637-bfe0-560e50850463.png">

fixes: #11 
