### PR TITLE
feat: add port mapping to lease details

### DIFF
--- a/web/src/components/DeploymentEvents/index.tsx
+++ b/web/src/components/DeploymentEvents/index.tsx
@@ -46,7 +46,7 @@ export interface DeploymentEventsProps {
 }
 
 export const DeploymentEvents: React.FC<DeploymentEventsProps> = (props) => {
-  const { dseq, lease } = props;
+  const { dseq, lease, leaseStatus } = props;
   const [value, setValue] = React.useState(0);
 
   const handleChange = (e: React.SyntheticEvent, newValue: number) => {
@@ -69,7 +69,7 @@ export const DeploymentEvents: React.FC<DeploymentEventsProps> = (props) => {
         <Logs lease={lease} />
       </DeploymentTab>
       <DeploymentTab value={value} index={2}>
-        <Leases dseq={dseq} lease={lease} />
+        <Leases dseq={dseq} lease={lease} status={leaseStatus} />
       </DeploymentTab>
     </Box>
   );

--- a/web/src/components/Leases/index.tsx
+++ b/web/src/components/Leases/index.tsx
@@ -11,11 +11,24 @@ import { DeploymentMissing } from '../SdlConfiguration/DeploymentMissing';
 interface LeaseProps {
   dseq: string;
   lease: any;
+  status: any; // TODO: fix type
 }
 
 type LabeledValue = { label: string; value: any };
 
-export const Leases: React.FC<LeaseProps> = ({ dseq, lease }) => {
+function formatPorts(services: Record<string, Array<{ externalPort: string, port: string, host: string }>> | undefined) {
+  if (services) {
+    return Object.values(services)
+      .map((service) => (
+        service.map(rule => `${rule.externalPort}: ${rule.port}`)
+      ))
+      .join("");
+  }
+
+  return "";
+}
+
+export const Leases: React.FC<LeaseProps> = ({ dseq, lease, status: leaseStatus }) => {
   const [providerDetails, setProviderDetails] = React.useState<Array<LabeledValue>>([]);
   const [status, setStatus] = React.useState<Array<LabeledValue>>([]);
   const [, setCapabilities] = React.useState<Array<LabeledValue>>([]);
@@ -38,6 +51,7 @@ export const Leases: React.FC<LeaseProps> = ({ dseq, lease }) => {
         if (attributes) {
           const _attributes = {} as any;
           const _capabilities = [] as any;
+
           for (const attribute of attributes) {
             if (attribute.key.includes('capabilities')) {
               _capabilities.push({ key: attribute.key, value: attribute.value });
@@ -45,6 +59,7 @@ export const Leases: React.FC<LeaseProps> = ({ dseq, lease }) => {
               _attributes[attribute.key] = attribute.value;
             }
           }
+
           setProviderDetails([
             { label: 'Name', value: _attributes?.organization },
             { label: 'Region', value: _attributes?.region },
@@ -60,6 +75,7 @@ export const Leases: React.FC<LeaseProps> = ({ dseq, lease }) => {
             { label: 'Data Center', value: _attributes?.data_center },
             { label: 'Generation', value: _attributes?.generation },
             { label: 'Host URI', value: provider?.provider?.hostUri },
+            { label: 'Forwarded Ports', value: formatPorts(leaseStatus?.forwarded_ports) }
           ]);
           setNetwork([
             { label: 'Network Download', value: _attributes?.network_download },


### PR DESCRIPTION
Add a forward ports field to the lease details

<img width="412" alt="image" src="https://user-images.githubusercontent.com/79639/218549075-4166ee04-727d-40c7-8843-b103224d01c1.png">

fixes: #8 
