### PR TITLE
feat: add status endpoint to proxy

### DIFF
--- a/proxy/src/index.ts
+++ b/proxy/src/index.ts
@@ -11,6 +11,10 @@ const app = fastify({
 app.register(cors, {});
 app.register(plugin, {});
 
+app.get('/status', (req, res) => {
+  res.send({ status: 'online' });
+});
+
 app.listen({ port: 3005, host: '0.0.0.0' }, (err, address) => {
   if (err) {
     console.error(err);


### PR DESCRIPTION
Adds a new endpoint `/status` to the proxy. This can be used to ensure the proxy is running, without causing any requests to other servers.
