### PR TITLE
fix: disable create cert button when not connected to a wallet

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -99,13 +99,13 @@ const AppRouter = () => {
 export default function App() {
   const [keplr, setKeplr] = useRecoilState(keplrState);
   const [certificate, setCertificate] = useRecoilState(activeCertificate);
-  const { status } = useWallet();
+  const { isConnected } = useWallet();
 
   useEffect(() => {
     let timer: NodeJS.Timeout | null = null;
 
     const checkKeplr = async () => {
-      if (status && window.keplr && keplr.accounts.length > 0 && keplr.accounts[0].address) {
+      if (isConnected && window.keplr && keplr.accounts.length > 0 && keplr.accounts[0].address) {
         const wallet = window.keplr.getOfflineSigner('akashnet-2');
 
         try {
@@ -139,7 +139,7 @@ export default function App() {
         clearTimeout(timer);
       }
     }
-  }, [status, certificate, setCertificate, keplr, setKeplr]);
+  }, [isConnected, certificate, setCertificate, keplr, setKeplr]);
 
   return (
     <Logging>

--- a/web/src/components/SideNav/index.tsx
+++ b/web/src/components/SideNav/index.tsx
@@ -83,7 +83,7 @@ export default function SideNav(props: any) {
           </Breadcrumbs>
           <div className="grow">{/* flex grow spacer */}</div>
           {
-            wallet.status
+            wallet.isConnected
               ? <Button variant="outlined" onClick={handleDisconnectWallet}>
                 <Box marginRight="0.5rem">
                   <Icon type='wallet' />

--- a/web/src/hooks/useWallet.ts
+++ b/web/src/hooks/useWallet.ts
@@ -47,7 +47,7 @@ export function useWallet() {
   };
 
   return {
-    status: isConnected,
+    isConnected,
     connect: connectWallet,
     disconnect: disconnectWallet,
   };

--- a/web/src/pages/MyDeployments.tsx
+++ b/web/src/pages/MyDeployments.tsx
@@ -17,7 +17,7 @@ type MyDeploymentsPlaceholderProps = {
 
 const MyDeploymentsPlaceholder: React.FC<MyDeploymentsPlaceholderProps> = ({ hidden }) => {
   const navigate = useNavigate();
-  const { status, connect } = useWallet();
+  const { isConnected, connect } = useWallet();
 
   const handleCreateDeployment = () => {
     navigate('/new-deployment');
@@ -37,7 +37,7 @@ const MyDeploymentsPlaceholder: React.FC<MyDeploymentsPlaceholderProps> = ({ hid
       )}
     </Typography >
     <Stack direction="row" padding="1.5rem" gap="1rem" justifyContent="center">
-      {status
+      {isConnected
         ? (
           <Button variant="contained" onClick={handleCreateDeployment}>
             <Box paddingRight="0.5rem">
@@ -95,7 +95,7 @@ const MyDeployments: React.FC<{}> = () => {
       <Stack direction="row" spacing={1} alignItems="center" sx={{ marginBottom: '24px' }}>
         <WordSwitch on="Active only" off="All" checked={!showAll} onChange={handleToggleAll} />
       </Stack>
-      {wallet.status
+      {wallet.isConnected
         ? <MyDeploymentsTable showAll={showAll} />
         : <MyDeploymentsPlaceholder hidden={0} />
       }

--- a/web/src/pages/PreflightCheck.tsx
+++ b/web/src/pages/PreflightCheck.tsx
@@ -52,7 +52,7 @@ export const PreflightCheck: React.FC<{}> = () => {
   }, [keplr]);
 
   const handleConnectWallet = async () => {
-    if (!wallet.status) {
+    if (!wallet.isConnected) {
       wallet.connect();
     }
   };

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -10,6 +10,7 @@ import {
   Grid,
   Paper,
   Stack,
+  Tooltip,
   Typography,
 } from '@mui/material';
 import styled from '@emotion/styled';
@@ -240,11 +241,19 @@ const Settings: React.FC<{}> = () => {
 
               {obj.title === 'Certificates' ? (
                 <div className="flex-none mb-2">
-                  <Button disabled={!keplr.isSignedIn} variant="outlined"
-                          title={keplr.isSignedIn ? "Generate new certificate" : "Connect your wallet first"}
-                          onClick={() => setCreateOpen(true)}>
-                    Generate New Certificate
-                  </Button>
+                  {keplr.isSignedIn ?
+                    <Button variant="outlined"
+                            onClick={() => setCreateOpen(true)}>
+                      Generate New Certificate
+                    </Button> :
+                    <Tooltip title="Connect wallet first">
+                      <span>
+                        <Button disabled variant="outlined"
+                              onClick={() => setCreateOpen(true)}>
+                          Generate New Certificate
+                        </Button>
+                      </span>
+                    </Tooltip>}
                 </div>
               ) : (
                 <div className="flex-none mb-2">{obj.value}</div>

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -10,7 +10,6 @@ import {
   Grid,
   Paper,
   Stack,
-  Tooltip,
   Typography,
 } from '@mui/material';
 import styled from '@emotion/styled';
@@ -34,6 +33,7 @@ import {
 import { AntSwitch } from '../components/Switch/AntSwitch';
 import { Address } from '../components/Address';
 import { useQuery } from 'react-query';
+import { useWallet } from "../hooks/useWallet";
 
 const queryCertificates = (query: any) => {
   const { queryKey: [, owner] } = query;
@@ -97,6 +97,11 @@ const Settings: React.FC<{}> = () => {
   const [showProgress, setShowProgress] = React.useState(false);
   const [fields, setFields] = React.useState<FieldInfo<string | TLSCertificate>[]>([]);
   const [optInto, setOptInto] = useRecoilState(optIntoAnalytics);
+  const wallet = useWallet();
+
+  const handleConnectWallet = (): void => {
+    wallet.connect();
+  }
 
   const availableCertificates = useMemo(
     () => getAvailableCertificates(keplr?.accounts[0]?.address),
@@ -241,19 +246,14 @@ const Settings: React.FC<{}> = () => {
 
               {obj.title === 'Certificates' ? (
                 <div className="flex-none mb-2">
-                  {keplr.isSignedIn ?
+                  {wallet.isConnected ?
                     <Button variant="outlined"
                             onClick={() => setCreateOpen(true)}>
                       Generate New Certificate
                     </Button> :
-                    <Tooltip title="Connect wallet first">
-                      <span>
-                        <Button disabled variant="outlined"
-                              onClick={() => setCreateOpen(true)}>
-                          Generate New Certificate
-                        </Button>
-                      </span>
-                    </Tooltip>}
+                    <Button variant="contained" onClick={handleConnectWallet}>
+                      Connect Wallet
+                    </Button>}
                 </div>
               ) : (
                 <div className="flex-none mb-2">{obj.value}</div>

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -240,7 +240,9 @@ const Settings: React.FC<{}> = () => {
 
               {obj.title === 'Certificates' ? (
                 <div className="flex-none mb-2">
-                  <Button variant="outlined" onClick={() => setCreateOpen(true)}>
+                  <Button disabled={!keplr.isSignedIn} variant="outlined"
+                          title={keplr.isSignedIn ? "Generate new certificate" : "Connect your wallet first"}
+                          onClick={() => setCreateOpen(true)}>
                     Generate New Certificate
                   </Button>
                 </div>


### PR DESCRIPTION
Changes the create cert button on preflight checklist to a connect wallet if the wallet isn't connect.
