### PR TITLE
fix: improve certificate check on preflight

### DIFF
--- a/web/src/pages/PreflightCheck.tsx
+++ b/web/src/pages/PreflightCheck.tsx
@@ -1,9 +1,9 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import styled from '@emotion/styled';
 import { Box, Button, Card, Stack, Tooltip } from '@mui/material';
-import { useRecoilState, useRecoilValue } from 'recoil';
+import { useRecoilState } from 'recoil';
 import { useFormikContext } from 'formik';
-import { activeCertificate, certificateList, keplrState, rpcEndpoint } from '../recoil/atoms';
+import { activeCertificate, keplrState, rpcEndpoint } from '../recoil/atoms';
 import { getAccountBalance } from '../recoil/api/bank';
 import { createAndBroadcastCertificate } from '../recoil/api';
 import { Icon } from '../components/Icons';
@@ -13,6 +13,8 @@ import { uaktToAKT } from '../_helpers/lease-calculations';
 import { useWallet } from '../hooks/useWallet';
 import { ManifestVersion } from '../_helpers/deployments-utils';
 import { SDLSpec } from '../components/SdlConfiguration/settings';
+import { queryCertificates } from '../recoil/queries';
+import { useQuery } from 'react-query';
 
 export const PreflightCheck: React.FC<{}> = () => {
   const [hasKeplr, setHasKeplr] = React.useState(false);
@@ -20,7 +22,10 @@ export const PreflightCheck: React.FC<{}> = () => {
   const [balance, setBalance] = React.useState(0);
   const { submitForm, values } = useFormikContext();
   const [certificate, setCertificate] = useRecoilState(activeCertificate);
-  const accountCertificates = useRecoilValue(certificateList(keplr?.accounts[0]?.address));
+  const { data: accountCertificates } = useQuery(
+    ['certificates', keplr?.accounts[0]?.address],
+    queryCertificates
+  );
   const wallet = useWallet();
   const [isValidCert, setIsValidCert] = React.useState(false);
   const sdl = (values as { sdl: SDLSpec }).sdl;

--- a/web/src/recoil/queries.ts
+++ b/web/src/recoil/queries.ts
@@ -1,0 +1,12 @@
+import { fetchCertificates } from "./api";
+import { rpcEndpoint } from "./atoms";
+
+export const queryCertificates = (context: any) => {
+  const { queryKey: [, owner] } = context;
+
+  if (owner !== undefined) {
+    return fetchCertificates({ owner }, rpcEndpoint);
+  }
+
+  return Promise.resolve([]);
+}


### PR DESCRIPTION
Removes the static atom from preflights and uses dynamic query to avoid a lot of stale data bugs

fixes #61 