### PR TITLE
fix: fix undefined error on preflight on first load

### DIFF
--- a/web/src/pages/PreflightCheck.tsx
+++ b/web/src/pages/PreflightCheck.tsx
@@ -41,12 +41,14 @@ export const PreflightCheck: React.FC<{}> = () => {
   }, [sdl])
 
   React.useEffect(() => {
-    const activeCert = accountCertificates.certificates.find((cert: any) => {
-      const pubKey = Buffer.from(cert.certificate.pubkey, 'base64').toString('ascii');
-      return certificate.$type === 'TLS Certificate' && certificate.publicKey === pubKey;
-    });
+    if (accountCertificates && accountCertificates.certificates) {
+      const activeCert = accountCertificates.certificates.find((cert: any) => {
+        const pubKey = Buffer.from(cert.certificate.pubkey, 'base64').toString('ascii');
+        return certificate.$type === 'TLS Certificate' && certificate.publicKey === pubKey;
+      });
 
-    setIsValidCert(activeCert && activeCert.certificate.state === 'valid');
+      setIsValidCert(activeCert && activeCert.certificate.state === 'valid');
+    }
   }, [certificate, accountCertificates]);
 
   React.useEffect(() => {


### PR DESCRIPTION
Fixes a bug where the user will experience an exception if the query cache doesn't contain the list of certificates for the wallet.
