### PR TITLE
feat: add option in settings to override rpc endpoint

### DIFF
--- a/web/src/_helpers/keplr-utils.ts
+++ b/web/src/_helpers/keplr-utils.ts
@@ -30,7 +30,7 @@ export const getKeplr = async (): Promise<KeplrWallet> => {
 
     // Initialize the gaia api with the offline signer that is injected by Keplr extension.
     const cosmJS = new SigningCosmosClient(
-      rpcEndpoint,
+      rpcEndpoint(),
       accounts[0].address,
       offlineSigner
     );

--- a/web/src/components/Bid/index.tsx
+++ b/web/src/components/Bid/index.tsx
@@ -39,7 +39,7 @@ type BidAuditTagProps = {
 const BidAuditTag: React.FC<BidAuditTagProps> = ({ bid }) => {
   const { data: attributes } = useQuery(
     ['providerAttributes', bid.bidId?.provider],
-    () => fetchProviderAttributes({ owner: bid.bidId?.provider || "" }, rpcEndpoint)
+    () => fetchProviderAttributes({ owner: bid.bidId?.provider || "" }, rpcEndpoint())
   );
 
   const isAudited = (attributes?.providers?.length || 0) > 0;
@@ -70,7 +70,7 @@ const isValidAuditor = (id: string): id is keyof typeof auditors => {
 const BidAuditBadges: React.FC<BidAuditBadgesProps> = ({ bid }) => {
   const { data: attributes } = useQuery(
     ['providerAttributes', bid.bidId?.provider],
-    () => fetchProviderAttributes({ owner: bid.bidId?.provider || "" }, rpcEndpoint)
+    () => fetchProviderAttributes({ owner: bid.bidId?.provider || "" }, rpcEndpoint())
   );
 
   return <>{
@@ -111,12 +111,12 @@ export const BidCard: React.FC<BidCardProps> = ({ bid, ...props }) => {
 
   const { data: provider } = useQuery(
     ['provider', providerId],
-    () => fetchProviderInfo({ owner: providerId || "" }, rpcEndpoint)
+    () => fetchProviderInfo({ owner: providerId || "" }, rpcEndpoint())
   )
 
   const { data: attributes } = useQuery(
     ['providerAttributes', bid.bidId?.provider],
-    () => fetchProviderAttributes({ owner: bid.bidId?.provider || "" }, rpcEndpoint)
+    () => fetchProviderAttributes({ owner: bid.bidId?.provider || "" }, rpcEndpoint())
   );
 
   const akt = useRecoilValue(aktMarketCap);

--- a/web/src/components/EventsTable/index.tsx
+++ b/web/src/components/EventsTable/index.tsx
@@ -6,13 +6,13 @@ import TableContainer from '@mui/material/TableContainer';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 import Paper from '@mui/material/Paper';
-import { providerInfo } from '../../recoil/atoms';
-import { useRecoilValue } from 'recoil';
 import { watchLeaseEvents } from '../../recoil/api';
 import { QueryLeaseResponse } from '@akashnetwork/akashjs/build/protobuf/akash/market/v1beta2/query';
+import { useQuery } from 'react-query';
+import { queryProviderInfo } from '../../recoil/queries';
 
 export const EventsTable: React.FC<{ lease: any }> = ({ lease }) => {
-  const provider = useRecoilValue(providerInfo(lease?.lease?.leaseId?.provider));
+  const { data: provider } = useQuery(['providerInfo', lease?.lease?.leaseId?.provider], queryProviderInfo);
   const [rows, setRows] = useState<any[]>([]);
   const address = (lease as QueryLeaseResponse).lease?.leaseId?.owner;
 

--- a/web/src/components/Leases/index.tsx
+++ b/web/src/components/Leases/index.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import { useRecoilValue } from 'recoil';
 import styled from '@emotion/styled';
 import Box from '@mui/material/Box';
 import Grid from '@mui/material/Grid';
 import Stack from '@mui/material/Stack';
 import Divider from '@mui/material/Divider';
-import { providerInfo } from '../../recoil/atoms';
 import { DeploymentMissing } from '../SdlConfiguration/DeploymentMissing';
+import { queryProviderInfo } from '../../recoil/queries';
+import { useQuery } from 'react-query';
 
 interface LeaseProps {
   dseq: string;
@@ -37,7 +37,7 @@ export const Leases: React.FC<LeaseProps> = ({ dseq, lease, status: leaseStatus 
   const [details, setDetails] = React.useState<Array<LabeledValue>>([]);
   const [capacity, setCapacity] = React.useState<Array<LabeledValue>>([]);
   const [, setInfo] = React.useState<Array<LabeledValue>>([]);
-  const provider = useRecoilValue(providerInfo(lease?.lease?.leaseId?.provider));
+  const { data: provider } = useQuery(['providerInfo', lease?.lease?.leaseId?.provider], queryProviderInfo)
   const attributes = provider?.provider?.attributes as any;
 
   const applicationCache = localStorage.getItem(dseq);

--- a/web/src/components/Logs/index.tsx
+++ b/web/src/components/Logs/index.tsx
@@ -4,13 +4,13 @@ import Button from '@mui/material/Button';
 import Stack from '@mui/material/Stack';
 import List from '@mui/material/List';
 import Checkbox from '@mui/material/Checkbox';
-import { providerInfo } from '../../recoil/atoms';
-import { useRecoilValue } from 'recoil';
 import { watchLeaseLogs } from '../../recoil/api';
 import { QueryLeaseResponse } from '@akashnetwork/akashjs/build/protobuf/akash/market/v1beta2/query';
+import { useQuery } from 'react-query';
+import { queryProviderInfo } from '../../recoil/queries';
 
 export const Logs: React.FC<any> = ({ lease }) => {
-  const provider = useRecoilValue(providerInfo(lease?.lease?.leaseId?.provider));
+  const { data: provider } = useQuery(['providerInfo', lease?.lease?.leaseId?.provider], queryProviderInfo);
   const address = (lease as QueryLeaseResponse).lease?.leaseId?.owner;
   const [logs, setLogs] = useState<any[]>([]);
   const [autoScrollWithOutput, setAutoScrollWithOutput] = useState(false);

--- a/web/src/components/ProviderDetails/index.tsx
+++ b/web/src/components/ProviderDetails/index.tsx
@@ -1,10 +1,10 @@
 import React, { useMemo } from 'react';
 import { Button, Card, CardContent, Divider, Grid, Stack, Typography } from '@mui/material';
-import { useRecoilValue } from 'recoil';
-import { providerInfo } from '../../recoil/atoms';
 import styled from '@emotion/styled';
 import { useNavigate } from 'react-router-dom';
 import { Address } from '../Address';
+import { queryProviderInfo } from '../../recoil/queries';
+import { useQuery } from 'react-query';
 
 export interface ProviderDetailsProps {
   providerId: string;
@@ -18,7 +18,8 @@ function attributeByName(attributes: any) {
 
 const ProviderDetails: React.FC<ProviderDetailsProps> = ({ providerId }) => {
   const navigate = useNavigate();
-  const { provider } = useRecoilValue(providerInfo(providerId));
+  const { data: response } = useQuery(['providerInfo', providerId], queryProviderInfo);
+  const provider = response?.provider;
 
   const attributes = useMemo(() => (
     provider?.attributes

--- a/web/src/hooks/useDeploymentData.ts
+++ b/web/src/hooks/useDeploymentData.ts
@@ -56,7 +56,7 @@ export default function useDeploymentData(owner: string) {
     (lease: any) => {
       if (certificate.$type === 'TLS Certificate') {
         // console.log('fetching status for lease', lease);
-        return lease && fetchLeaseStatus(lease, certificate);
+        return lease && fetchLeaseStatus(lease);
       }
     },
     [certificate]

--- a/web/src/hooks/useLeaseStatus.ts
+++ b/web/src/hooks/useLeaseStatus.ts
@@ -56,7 +56,7 @@ export function useLeaseStatus(lease: Lease) {
     if (lease?.leaseId) {
       const { provider } = lease.leaseId;
 
-      fetchProviderInfo({ owner: provider }, rpcEndpoint)
+      fetchProviderInfo({ owner: provider }, rpcEndpoint())
         .then(response => setProviderInfo(response?.provider));
     }
   }, [lease])

--- a/web/src/hooks/useRpcNode.ts
+++ b/web/src/hooks/useRpcNode.ts
@@ -23,5 +23,5 @@ export function useRpcNode() {
   return [
     getRpcNode,
     setRpcNode
-  ];
+  ] as [typeof getRpcNode, typeof setRpcNode];
 }

--- a/web/src/hooks/useRpcNode.ts
+++ b/web/src/hooks/useRpcNode.ts
@@ -1,7 +1,23 @@
 import { proxyURL } from '../recoil/api/mtls';
 
+const storageKey = 'rpc_endpoint';
+const defaultRpcNode = 'https://rpc.ny.akash.farm/token/TBWM93ZB';
+
+function getRpcFromStorageOrDefault(defaultValue: string) {
+  const raw = localStorage.getItem(storageKey);
+  return raw ? raw : defaultValue;
+}
+
+function saveRpcToStorage(rpcNode: string) {
+  localStorage.setItem(storageKey, rpcNode);
+}
+
+function deleteRpcFromStorage() {
+  localStorage.removeItem(storageKey);
+}
+
 export const [getRpcNode, setRpcNode] = (() => {
-  let rpcNode = 'https://rpc.ny.akash.farm/token/TBWM93ZB';
+  let rpcNode = getRpcFromStorageOrDefault(defaultRpcNode);
 
   function get(proxy: Boolean = false): string {
     const rpcEndpointURL = new URL(rpcNode);
@@ -13,6 +29,7 @@ export const [getRpcNode, setRpcNode] = (() => {
 
   function set(value: string): Promise<string> {
     rpcNode = value;
+    saveRpcToStorage(rpcNode);
     return Promise.resolve(rpcNode);
   }
 

--- a/web/src/hooks/useRpcNode.ts
+++ b/web/src/hooks/useRpcNode.ts
@@ -1,0 +1,27 @@
+import { proxyURL } from '../recoil/api/mtls';
+
+export const [getRpcNode, setRpcNode] = (() => {
+  let rpcNode = 'https://rpc.ny.akash.farm/token/TBWM93ZB';
+
+  function get(proxy: Boolean = false): string {
+    const rpcEndpointURL = new URL(rpcNode);
+
+    return proxy
+      ? `${proxyURL}upstream/${rpcEndpointURL.protocol.slice(0, -1)}/${rpcEndpointURL.hostname}/${rpcEndpointURL.port || "443"}${rpcEndpointURL.pathname}`
+      : rpcNode;
+  }
+
+  function set(value: string): Promise<string> {
+    rpcNode = value;
+    return Promise.resolve(rpcNode);
+  }
+
+  return [get, set];
+})();
+
+export function useRpcNode() {
+  return [
+    getRpcNode,
+    setRpcNode
+  ];
+}

--- a/web/src/pages/PreflightCheck.tsx
+++ b/web/src/pages/PreflightCheck.tsx
@@ -15,6 +15,7 @@ import { ManifestVersion } from '../_helpers/deployments-utils';
 import { SDLSpec } from '../components/SdlConfiguration/settings';
 import { queryCertificates } from '../recoil/queries';
 import { useQuery } from 'react-query';
+import { Certificate_State } from '@akashnetwork/akashjs/build/protobuf/akash/cert/v1beta2/cert';
 
 export const PreflightCheck: React.FC<{}> = () => {
   const [hasKeplr, setHasKeplr] = React.useState(false);
@@ -47,7 +48,7 @@ export const PreflightCheck: React.FC<{}> = () => {
         return certificate.$type === 'TLS Certificate' && certificate.publicKey === pubKey;
       });
 
-      setIsValidCert(activeCert && activeCert.certificate.state === 'valid');
+      setIsValidCert(!!(activeCert && activeCert?.certificate?.state === Certificate_State.valid));
     }
   }, [certificate, accountCertificates]);
 
@@ -78,7 +79,7 @@ export const PreflightCheck: React.FC<{}> = () => {
   };
 
   const handleCreateCertificate = async () => {
-    const result = await createAndBroadcastCertificate(rpcEndpoint, keplr);
+    const result = await createAndBroadcastCertificate(rpcEndpoint(), keplr);
 
     if (result.code === 0 && result.certificate) {
       setCertificate(result.certificate);

--- a/web/src/pages/SelectProvider.tsx
+++ b/web/src/pages/SelectProvider.tsx
@@ -49,9 +49,10 @@ export default function SelectProvider(
     deploymentId
   }: SelectProviderProps): JSX.Element {
 
+  // TODO: this should be moved into queries.ts
   const { data: bids } = useQuery(
     ["bids", deploymentId],
-    () => fetchBidsList(deploymentId, rpcEndpoint)
+    () => fetchBidsList(deploymentId, rpcEndpoint())
       .then((resp) => resp.bids
         .filter(resp => resp.bid !== undefined)
         .map(resp => resp.bid as Bid)),

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -8,6 +8,7 @@ import {
   DialogContent,
   DialogTitle,
   Grid,
+  Input,
   Paper,
   Stack,
   Typography,
@@ -34,7 +35,8 @@ import { Address } from '../components/Address';
 import { useQuery } from 'react-query';
 import { useWallet } from "../hooks/useWallet";
 import { queryCertificates } from '../recoil/queries';
-import { CertificateResponse, QueryCertificatesResponse } from '@akashnetwork/akashjs/build/protobuf/akash/cert/v1beta2/query';
+import { QueryCertificatesResponse } from '@akashnetwork/akashjs/build/protobuf/akash/cert/v1beta2/query';
+import { useRpcNode } from '../hooks/useRpcNode';
 
 type SortableCertificate = { available: boolean, current: boolean, certificate: { state: string }, serial: string };
 
@@ -88,6 +90,7 @@ const Settings: React.FC<{}> = () => {
   const [showProgress, setShowProgress] = React.useState(false);
   const [fields, setFields] = React.useState<FieldInfo<string | TLSCertificate>[]>([]);
   const [optInto, setOptInto] = useRecoilState(optIntoAnalytics);
+  const [getRpcNode, setRpcNode] = useRpcNode();
   const wallet = useWallet();
 
   const handleConnectWallet = (): void => {
@@ -142,7 +145,14 @@ const Settings: React.FC<{}> = () => {
       return;
     }
 
-    const certificateList = (QueryCertificatesResponse.toJSON(certificates) as any).certificates;
+    // TODO: figure out why this throws an exception for some certs
+    let certificateList: any[] = [];
+    try {
+      certificateList = (QueryCertificatesResponse.toJSON(certificates) as any).certificates;
+    } catch (e) {
+      console.error(e, certificates);
+      return;
+    }
 
     for (const cert of certificateList) {
       const pubKey = Buffer.from(cert.certificate.pubkey, 'base64').toString('ascii');
@@ -214,6 +224,12 @@ const Settings: React.FC<{}> = () => {
       </Grid>
       <Grid item xs={10}>
         <SettingsCard>
+          <SettingsField>
+            <div className="text-base font-bold text-[#111827]">RPC Endpoint</div>
+            <div className="flex-none">
+              <SettingOptionText initialValue={getRpcNode()} onChange={setRpcNode} />
+            </div>
+          </SettingsField>
           {fields.map((obj: any, i: number) => (
             <SettingsField key={i}>
               <div className="flex-none">
@@ -235,8 +251,6 @@ const Settings: React.FC<{}> = () => {
                 ) : null}
               </div>
 
-              <div className="grow">{/* spacer */}</div>
-
               {obj.title === 'Certificates' ? (
                 <div className="flex-none mb-2">
                   {wallet.isConnected ?
@@ -249,7 +263,7 @@ const Settings: React.FC<{}> = () => {
                     </Button>}
                 </div>
               ) : (
-                <div className="flex-none mb-2">{obj.value}</div>
+                <div className="flex-none">{obj.value}</div>
               )}
             </SettingsField>
           ))}
@@ -423,6 +437,26 @@ const Settings: React.FC<{}> = () => {
 
 export default Settings;
 
+const SettingOptionText = (props: { initialValue: string; onChange: (newVal: string) => void }) => {
+  const updateValue = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    props.onChange(e.target.value);
+  }, [props.onChange]);
+
+  return <div>
+    <SettingsInput defaultValue={props.initialValue} onChange={updateValue}></SettingsInput>
+  </div>;
+};
+
+const SettingsInput = styled.input`
+        width: 24rem;
+        padding: 10px 16px;
+        border: 1px solid #D7D7D7;
+        border-radius: 6px;
+        font-weight: 500;
+        border: 1px solid #d7d7d7;
+        text-align: right;
+        `;
+
 const SettingsCard = styled(Paper)`
         padding: 24px;
         text-align: left;
@@ -432,6 +466,8 @@ const SettingsCard = styled(Paper)`
 
 const SettingsField = styled.div`
         display: flex;
+        justify-content: space-between;
+        align-items: center;
         padding: 16px 0 16px;
         border-bottom: 1px solid gainsboro;
         `;

--- a/web/src/recoil/api/bank.ts
+++ b/web/src/recoil/api/bank.ts
@@ -4,7 +4,7 @@ import { getRpc } from '@akashnetwork/akashjs/build/rpc';
 import { rpcEndpoint } from "../atoms";
 
 export async function getAccountBalance(address: string) {
-  const rpc = await getRpc(rpcEndpoint);
+  const rpc = await getRpc(rpcEndpoint());
   const client = new BankClient(rpc);
   const request = await client.Balance({
     address: address,

--- a/web/src/recoil/api/certificates.tsx
+++ b/web/src/recoil/api/certificates.tsx
@@ -74,7 +74,7 @@ export const fetchCertificates = async (filter: CertificateFilter, rpcEndpoint: 
   const client = new QueryClientImpl(rpc);
   const response = await client.Certificates(request);
 
-  return QueryCertificatesResponse.toJSON(response) as any;
+  return response;
 }
 
 export const getActiveSerial = (walletId: string) => {

--- a/web/src/recoil/atoms.ts
+++ b/web/src/recoil/atoms.ts
@@ -8,6 +8,7 @@ import { AccountData, CosmosClient, OfflineSigner } from '@cosmjs/launchpad';
 import { proxyURL } from './api/mtls';
 import fetchPriceAndMarketCap from './api/akt';
 import { SDLSpec } from '../components/SdlConfiguration/settings';
+import { getRpcNode } from '../hooks/useRpcNode';
 
 export interface KeplrWallet {
   accounts: AccountData[];
@@ -17,12 +18,16 @@ export interface KeplrWallet {
   file?: string;
 }
 
+// Deprecated. Use getRpcNode instead.
 export const rpcEndpointBase = 'https://rpc.ny.akash.farm/token/TBWM93ZB';
 export const rpcEndpointURL = new URL(rpcEndpointBase);
 export const rpcProxyEndpoint = (
   `${proxyURL}upstream/${rpcEndpointURL.protocol.slice(0, -1)}/${rpcEndpointURL.hostname}/${rpcEndpointURL.port || "443"}${rpcEndpointURL.pathname}`
 );
-export const rpcEndpoint = () => rpcEndpointBase;
+
+// Located in this file for backwards compatibility
+// TODO: Move to a more appropriate location
+export const rpcEndpoint = getRpcNode;
 
 export const appVersion = atom({
   key: 'appVersion',
@@ -40,6 +45,7 @@ export const keplrState = atom<KeplrWallet>({
   },
 });
 
+// TODO: Don't think this is used anymore. Validate and remove if so.
 export const rpcState = atom({
   key: 'rpcState',
   default: {

--- a/web/src/recoil/atoms.ts
+++ b/web/src/recoil/atoms.ts
@@ -1,21 +1,11 @@
 import { atom, AtomEffect, atomFamily, RecoilLoadable } from 'recoil';
 import pkg from '../../package.json';
 import {
-  fetchCertificates,
-  fetchDeployment,
-  fetchLeaseStatus,
   loadActiveCertificate,
 } from './api';
 
 import { AccountData, CosmosClient, OfflineSigner } from '@cosmjs/launchpad';
-import { fetchRpcNodeStatus } from './api/rpc';
 import { proxyURL } from './api/mtls';
-import {
-  fetchAuditorAttributes,
-  fetchProviderAttributes,
-  fetchProviderInfo,
-  fetchProvidersList,
-} from './api/providers';
 import fetchPriceAndMarketCap from './api/akt';
 import { SDLSpec } from '../components/SdlConfiguration/settings';
 
@@ -32,9 +22,7 @@ export const rpcEndpointURL = new URL(rpcEndpointBase);
 export const rpcProxyEndpoint = (
   `${proxyURL}upstream/${rpcEndpointURL.protocol.slice(0, -1)}/${rpcEndpointURL.hostname}/${rpcEndpointURL.port || "443"}${rpcEndpointURL.pathname}`
 );
-export const rpcEndpoint = rpcEndpointBase;
-
-console.log(rpcEndpointURL)
+export const rpcEndpoint = () => rpcEndpointBase;
 
 export const appVersion = atom({
   key: 'appVersion',
@@ -59,40 +47,6 @@ export const rpcState = atom({
     currentRPC: '',
     rpcs: [],
   },
-});
-
-export const deploymentInfo = atomFamily({
-  key: 'DeploymentInfo',
-  default: (deploymentId: { owner: string; dseq: string }) =>
-    RecoilLoadable.of(fetchDeployment(deploymentId.owner, deploymentId.dseq)),
-});
-
-export const leaseStatus = atomFamily({
-  key: 'LeaseStatus',
-  default: (params: string) => {
-    const { leaseId, certificate } = JSON.parse(params);
-    return RecoilLoadable.of(fetchLeaseStatus(leaseId, certificate));
-  },
-});
-
-export const providerList = atomFamily({
-  key: 'Providers',
-  default: () => RecoilLoadable.of(fetchProvidersList(rpcEndpoint)),
-});
-
-export const providerInfo = atomFamily({
-  key: 'ProviderInfo',
-  default: (owner: string) => RecoilLoadable.of(fetchProviderInfo({ owner }, rpcEndpoint)),
-});
-
-export const certificateList = atomFamily({
-  key: 'Certificates',
-  default: (owner: string) => RecoilLoadable.of(fetchCertificates({ owner }, rpcEndpoint)),
-});
-
-export const rpcNodeStatus = atom({
-  key: 'RpcNodeStatus',
-  default: RecoilLoadable.of(fetchRpcNodeStatus(rpcEndpoint)),
 });
 
 export const deploymentSdl = atom<SDLSpec | undefined>({
@@ -133,16 +87,6 @@ export const myDeployments = atom({
   key: 'myDeployments',
   default: {},
   effects: [localStorageEffect('my_deployments')],
-});
-
-export const providerAttributes = atomFamily({
-  key: 'providerAttributes',
-  default: (owner: string) => RecoilLoadable.of(fetchProviderAttributes({ owner }, rpcEndpoint)),
-});
-
-export const auditorAttributes = atomFamily({
-  key: 'auditorAttributes',
-  default: (auditor: string) => RecoilLoadable.of(fetchAuditorAttributes({ auditor }, rpcEndpoint)),
 });
 
 export const showKeplrWindow = atom({

--- a/web/src/recoil/queries.ts
+++ b/web/src/recoil/queries.ts
@@ -1,12 +1,69 @@
-import { fetchCertificates } from "./api";
+import { QueryFunction, QueryFunctionContext } from "react-query";
+import { fetchCertificates, fetchDeployment, fetchLeaseStatus } from "./api";
 import { rpcEndpoint } from "./atoms";
+import { fetchAuditorAttributes, fetchProviderAttributes, fetchProviderInfo, fetchProvidersList } from "./api/providers";
+import { fetchRpcNodeStatus } from "./api/rpc";
+import { Lease } from "@akashnetwork/akashjs/build/protobuf/akash/market/v1beta2/lease";
 
-export const queryCertificates = (context: any) => {
-  const { queryKey: [, owner] } = context;
+function createQueryFunction<T, R>(fn: (args: T) => Promise<R>): QueryFunction<R, [string, T]> {
+  return (context: QueryFunctionContext<[string, T]>) => {
+    const { queryKey: [, args] } = context;
+    return fn(args);
+  };
+}
 
-  if (owner !== undefined) {
-    return fetchCertificates({ owner }, rpcEndpoint);
+export const queryCertificates = createQueryFunction((owner: string | undefined) => {
+  if (owner === undefined) {
+    return Promise.resolve(undefined);
   }
 
-  return Promise.resolve([]);
-}
+  return fetchCertificates({ owner }, rpcEndpoint());
+});
+
+export const queryProviders = createQueryFunction(() => {
+  return fetchProvidersList(rpcEndpoint());
+});
+
+export const queryProviderInfo = createQueryFunction((owner: string) => {
+  if (owner === undefined) {
+    return Promise.resolve(undefined);
+  }
+
+  return fetchProviderInfo({ owner }, rpcEndpoint());
+});
+
+export const queryProviderAttributes = createQueryFunction((owner: string) => {
+  if (owner === undefined) {
+    return Promise.resolve(undefined);
+  }
+
+  return fetchProviderAttributes({ owner }, rpcEndpoint());
+});
+
+export const queryAuditorAttributes = createQueryFunction((auditor: string) => {
+  if (auditor === undefined) {
+    return Promise.resolve(undefined);
+  }
+
+  return fetchAuditorAttributes({ auditor }, rpcEndpoint());
+});
+
+export const queryRpcNodeStatus = createQueryFunction(() => {
+  return fetchRpcNodeStatus(rpcEndpoint());
+});
+
+export const deploymentInfo = createQueryFunction((deploymentId: { owner: string, dseq: string }) => {
+  if (!deploymentId?.owner || !deploymentId?.dseq) {
+    return Promise.resolve(undefined);
+  }
+
+  return fetchDeployment(deploymentId.owner, deploymentId.dseq);
+});
+
+export const leaseStatus = createQueryFunction((leaseId: Lease) => {
+  if (!leaseId) {
+    return Promise.resolve(undefined);
+  }
+
+  return fetchLeaseStatus(leaseId);
+});


### PR DESCRIPTION
Adds a new option in the settings page to change the endpoint used for RPC requests.

<img width="903" alt="image" src="https://user-images.githubusercontent.com/79639/227674880-e921f654-ea63-49b7-8524-08ab63031b86.png">

Currently there is no validation on the input, so caution should be used when setting.

fixes #7 