### PR TITLE
Fix: fixed logs scroll hidden issue

### DIFF
--- a/web/src/components/DeploymentEvents/index.tsx
+++ b/web/src/components/DeploymentEvents/index.tsx
@@ -21,12 +21,10 @@ const DeploymentTab: React.FC<DeploymentTabProps> = (props) => {
       hidden={value !== index}
       id={`simple-tabpanel-${index}`}
       aria-labelledby={`simple-tab-${index}`}
-      style={{height: "100%", position: "relative"}}
+      style={{ height: '100%', position: 'relative' }}
       {...other}
     >
-      {value === index && (
-          <>{children}</>
-      )}
+      {value === index && <>{children}</>}
     </div>
   );
 };
@@ -53,7 +51,16 @@ export const DeploymentEvents: React.FC<DeploymentEventsProps> = (props) => {
   };
 
   return (
-    <Box sx={{ width: '100%', height: '100%', p: 0, position: "relative"}}>
+    <Box
+      sx={{
+        width: '100%',
+        height: '100%',
+        p: 0,
+        position: 'relative',
+        display: 'flex',
+        flexDirection: 'column',
+      }}
+    >
       <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
         <Tabs value={value} onChange={handleChange} aria-label="deployment event tabs">
           <Tab label="Events" {...tabProps(0)} />

--- a/web/src/components/Logs/index.tsx
+++ b/web/src/components/Logs/index.tsx
@@ -10,7 +10,10 @@ import { useQuery } from 'react-query';
 import { queryProviderInfo } from '../../recoil/queries';
 
 export const Logs: React.FC<any> = ({ lease }) => {
-  const { data: provider } = useQuery(['providerInfo', lease?.lease?.leaseId?.provider], queryProviderInfo);
+  const { data: provider } = useQuery(
+    ['providerInfo', lease?.lease?.leaseId?.provider],
+    queryProviderInfo
+  );
   const address = (lease as QueryLeaseResponse).lease?.leaseId?.owner;
   const [logs, setLogs] = useState<any[]>([]);
   const [autoScrollWithOutput, setAutoScrollWithOutput] = useState(false);
@@ -60,9 +63,17 @@ export const Logs: React.FC<any> = ({ lease }) => {
   };
 
   return (
-    <div style={{position: "absolute", width: "100%", height: "66%"}}>
+    <div
+      style={{
+        position: 'absolute',
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+      }}
+    >
       <div className="p-2 text-xl font-bold">Application Logs</div>
-      <LogsWrapper>
+      <LogsWrapper className='flex-1'>
         <ul>
           {logs.map((log: any, i: number) => (
             <LogList key={`log-line-${i}`}>
@@ -95,7 +106,6 @@ const LogsWrapper = styled.div`
   background-color: black;
   width: 100%;
   height: 100%,
-  max-height: 65vh;
   overflow-x: scroll;
   overflow-y: scroll;
 `;

--- a/web/src/components/Logs/index.tsx
+++ b/web/src/components/Logs/index.tsx
@@ -54,7 +54,7 @@ export const Logs: React.FC<any> = ({ lease }) => {
 
   useEffect(() => {
     if (autoScrollWithOutput) {
-      bottomRef.current?.scrollIntoView({ behavior: 'smooth', block: 'end', inline: 'nearest' });
+      bottomRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start', inline: 'nearest' });
     }
   }, [logs, autoScrollWithOutput]);
 


### PR DESCRIPTION
Fixed issue regrading user not being able to scroll logs and couldn't select auto scrolling checkbox

before:
[Screencast from 25-03-23 10:25:37 AM IST.webm](https://user-images.githubusercontent.com/51870483/227697851-b3eec545-a48d-4cf2-9b1f-845c727bb4f1.webm)

After:
[Screencast from 25-03-23 10:49:44 AM IST.webm](https://user-images.githubusercontent.com/51870483/227697953-43162786-67e3-486a-806d-3293805374c1.webm)

