### PR TITLE
chore: tie help to console docs

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -30,6 +30,12 @@ const Welcome = () => {
   return <></>;
 };
 
+const Help = () => {
+  window.location.href = 'https://docs.akash.network/guides/deploy';
+
+  return <></>;
+};
+
 const AppRouter = () => {
   return (
     <Router>
@@ -89,6 +95,7 @@ const AppRouter = () => {
                 <Settings />
               }
             />
+            <Route path='help' element={<Help />}/>
           </Routes>
         </SideNav>
       </div>

--- a/web/src/components/SideNav/index.tsx
+++ b/web/src/components/SideNav/index.tsx
@@ -159,6 +159,8 @@ export default function SideNav(props: any) {
             </NavLink>
             <NavLink
               to="help"
+              target="_blank"
+              rel="noreferrer noopener"
               id="link_help"
               className={({ isActive }) => (isActive ? 'selected-active' : 'selected-inactive')}
             >


### PR DESCRIPTION
This PR fixes #80 

**Description:**
Clicking on the help button in the console opens the [console docs](https://docs.akash.network/guides/deploy) in a new tab.