### PR TITLE
feat: add quick-and-dirty type guard for sdl-like objects

### DIFF
--- a/web/src/components/SdlConfiguration/settings.ts
+++ b/web/src/components/SdlConfiguration/settings.ts
@@ -142,3 +142,13 @@ export interface SDLSpec {
     }
   };
 }
+
+// Quick and dirty type guard for SDL like objects
+export function isSDLSpec(sdl: unknown): sdl is SDLSpec {
+  const sdlSpec = sdl as SDLSpec;
+
+  return sdlSpec.version === "2.0" &&
+    typeof sdlSpec.services === "object" &&
+    typeof sdlSpec.profiles === "object" &&
+    typeof sdlSpec.deployment === "object";
+}


### PR DESCRIPTION
Adds a type guard check for validating unknown objects before assuming they are SDL like. Still could use a lot of improvements, but this is a start.
