### PR TITLE
fix: improve formatting of single-topology templates

### DIFF
--- a/web/src/components/WalletDeployButton/index.tsx
+++ b/web/src/components/WalletDeployButton/index.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
 import styled from '@emotion/styled';
 import { Box } from '@mui/material';
 import { truncate } from "lodash";
+import React from 'react';
 import CheckedImage from "../../assets/images/checkmark-red.svg";
 import { Template } from "../SdlConfiguration/settings";
 
@@ -10,6 +10,7 @@ export interface WalletDeployButtonProps {
   typology: Template
   onButtonSelect: (template: Template) => void
   index: number
+  length: number
 
   [key: string]: any
 }
@@ -20,6 +21,7 @@ export const WalletDeployButtons: React.FC<WalletDeployButtonProps> = (
     typology,
     onButtonSelect,
     index,
+    length,
     ...field
   }) => {
   return (
@@ -29,6 +31,7 @@ export const WalletDeployButtons: React.FC<WalletDeployButtonProps> = (
       }}>
       <WalletDeployButtonWrapper
         checked={selected?.title === typology.title}
+        length={length}
         onClick={() => onButtonSelect(typology)}
       >
         <WalletDeployHeadline>
@@ -57,7 +60,7 @@ export const WalletDeployButtons: React.FC<WalletDeployButtonProps> = (
   );
 };
 
-const WalletDeployButtonWrapper = styled.div<{ checked?: boolean }>`
+const WalletDeployButtonWrapper = styled.div<{ checked?: boolean, length?: number }>`
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
@@ -65,7 +68,7 @@ const WalletDeployButtonWrapper = styled.div<{ checked?: boolean }>`
   padding: 16px 20px;
   gap: 16px;
   cursor: pointer;
-  width: 100%;
+  width: ${(props) => (props.length == 1 ? '33%' : '100%')};
   height: 180px;
 
   background: #ffffff;
@@ -118,4 +121,3 @@ const WalletDeployButtonDescription = styled.p`
   letter-spacing: 0.015em;
   color: #3d4148;
 `;
-

--- a/web/src/pages/SelectApp.tsx
+++ b/web/src/pages/SelectApp.tsx
@@ -1,15 +1,15 @@
-import React, { useEffect, useState } from 'react';
 import styled from '@emotion/styled';
 import { Avatar, Button, Stack } from '@mui/material';
-import { WalletDeployButtons } from '../components/WalletDeployButton';
 import axios from 'axios';
 import yaml from 'js-yaml';
-import { transformSdl } from '../_helpers/helpers';
-import { fetchSdlList, templateList } from '../recoil/api/sdl';
-import { Template } from '../components/SdlConfiguration/settings';
+import React, { useEffect, useState } from 'react';
 import { useQuery } from 'react-query';
+import { transformSdl } from '../_helpers/helpers';
 import { ButtonTemplate } from '../components/Button';
 import SocialIcon from "../components/Icons/SocialIcon";
+import { Template } from '../components/SdlConfiguration/settings';
+import { WalletDeployButtons } from '../components/WalletDeployButton';
+import { fetchSdlList, templateList } from '../recoil/api/sdl';
 
 type SocialNetwork = {
   socialNetwork: string,
@@ -102,13 +102,13 @@ export default function SelectApp(props: SelectAppProps): JSX.Element {
         {directoryConfig?.topology && (
           <React.Fragment>
             <Divider />
-            {directoryConfig?.topology.topologyList?.length > 1 && (
+            {directoryConfig?.topology.topologyList?.length >= 1 && (
               <SdlInformationTitle fontWeight={500}>
                 Choose from one of the available topology options
               </SdlInformationTitle>
             )}
             <TypologyWrapper>
-              {directoryConfig?.topology.topologyList?.length > 1 &&
+              {directoryConfig?.topology.topologyList?.length >= 1 &&
                 directoryConfig?.topology.topologyList?.map((typology: Template, index: number) => {
                   return (
                     <WalletDeployButtons
@@ -116,10 +116,12 @@ export default function SelectApp(props: SelectAppProps): JSX.Element {
                       typology={typology}
                       selected={selectedSdl}
                       index={index}
+                      length={directoryConfig.topology.topologyList.length}
                       onButtonSelect={selectTemplateAndFetchSdl}
                     />
                   );
-                })}
+                })} 
+                
             </TypologyWrapper>
             <DeployButton
               variant='contained'


### PR DESCRIPTION
Let me know if you are good with my solution, specifically, how I am hardcoding the width of the tile when there is only 1 element in the topology list. I personally thought the UX/UI was superior like this instead of the sub-tile spanning the entire width. I've attached images of both solutions.

<img width="930" alt="Screen Shot 2023-04-07 at 3 11 38 PM" src="https://user-images.githubusercontent.com/32280951/230752463-8f5b87dd-2fe6-471e-8a1e-550869cea773.png">
<img width="928" alt="Screen Shot 2023-04-07 at 3 12 07 PM" src="https://user-images.githubusercontent.com/32280951/230752464-74c29716-b7b7-4105-8526-a6618fc0630e.png">


Let me know what you think. 

Thanks.  

Fixes #99 