### PR TITLE
fix: cost misleading usd/akt labeling for deployment costs

### DIFF
--- a/web/src/_helpers/lease-calculations.ts
+++ b/web/src/_helpers/lease-calculations.ts
@@ -30,11 +30,11 @@ export function ceilDecimal(value: number) {
   return Math.ceil((value + Number.EPSILON) * 100) / 100;
 }
 
-export function getAvgCostPerMonth(leasePriceAmount: number, priceData: number) {
+export function getAvgAktCostPerMonth(leasePriceAmount: number) {
   const price = uaktToAKT(leasePriceAmount, 6);
   const averagePrice = price * (60 / averageBlockTimeInSeconds) * 60 * 24 * averageDaysInMonth;
 
-  const _value = parseFloat(averagePrice.toString()) * priceData;
+  const _value = parseFloat(averagePrice.toString());
   const computedValue = _value > 0 ? ceilDecimal(_value) : 0;
   return computedValue;
 }
@@ -57,11 +57,13 @@ export function leaseCalculator(deployment: Deployment | undefined, escrowAccoun
   const escrowTransferredAmount = escrowAccount.transferred ? decCoinToNum(escrowAccount.transferred) : 0;
 
   // data returned
-  const costAkt = getAvgCostPerMonth(leasePriceAmount, aktCurrentPrice);
+  const costAkt = getAvgAktCostPerMonth(leasePriceAmount);
   const costUsd = costAkt * aktCurrentPrice;
   const balanceAkt = uaktToAKT(escrowBalanceAmount);
   const balanceUsd = balanceAkt * aktCurrentPrice;
   const spentAkt = uaktToAKT(escrowTransferredAmount);
+  console.log(escrowTransferredAmount);
+  
   const spentUsd = spentAkt * aktCurrentPrice;
   const timeLeft = getTimeLeft(leasePriceAmount, escrowBalanceAmount);
 

--- a/web/src/_helpers/lease-calculations.ts
+++ b/web/src/_helpers/lease-calculations.ts
@@ -62,8 +62,6 @@ export function leaseCalculator(deployment: Deployment | undefined, escrowAccoun
   const balanceAkt = uaktToAKT(escrowBalanceAmount);
   const balanceUsd = balanceAkt * aktCurrentPrice;
   const spentAkt = uaktToAKT(escrowTransferredAmount);
-  console.log(escrowTransferredAmount);
-  
   const spentUsd = spentAkt * aktCurrentPrice;
   const timeLeft = getTimeLeft(leasePriceAmount, escrowBalanceAmount);
 

--- a/web/src/components/Bid/index.tsx
+++ b/web/src/components/Bid/index.tsx
@@ -5,7 +5,7 @@ import { useRecoilValue } from 'recoil';
 import { aktMarketCap, rpcEndpoint } from '../../recoil/atoms';
 import { Address } from '../Address';
 import { formatCurrency } from '../../_helpers/formatter-currency';
-import { getAvgCostPerMonth } from '../../_helpers/lease-calculations';
+import { getAvgAktCostPerMonth } from '../../_helpers/lease-calculations';
 import { useNavigate } from 'react-router-dom';
 import moultireLogo from '../../assets/images/moultire-logo.svg';
 import ovrclkLogo from '../../assets/images/overclk-logo.svg';
@@ -120,7 +120,7 @@ export const BidCard: React.FC<BidCardProps> = ({ bid, ...props }) => {
   );
 
   const akt = useRecoilValue(aktMarketCap);
-  const price = getAvgCostPerMonth(Number(bid?.price?.amount), akt?.current_price || 0);
+  const price = getAvgAktCostPerMonth(Number(bid?.price?.amount)) * (akt?.current_price || 0);
   const navigate = useNavigate();
 
   const handleOpen = () => navigate(`/provider/${provider?.provider?.owner}`);

--- a/web/src/components/Deployment/index.tsx
+++ b/web/src/components/Deployment/index.tsx
@@ -135,15 +135,15 @@ const Deployment: React.FC<any> = () => {
               },
               {
                 label: 'Cost/Month',
-                value: `${formatCurrency.format(leaseCost.costUsd)} / ${leaseCost.costAkt} AKT`,
+                value: `${formatCurrency.format(leaseCost.costUsd)} | ${leaseCost.costAkt} AKT`,
               },
               {
                 label: 'Spent',
-                value: `${formatCurrency.format(leaseCost.spentUsd)} / ${leaseCost.spentAkt} AKT`,
+                value: `${formatCurrency.format(leaseCost.spentUsd)} | ${leaseCost.spentAkt} AKT`,
               },
               {
                 label: 'Balance',
-                value: `${formatCurrency.format(leaseCost.balanceUsd)} / ${leaseCost.balanceAkt} AKT`,
+                value: `${formatCurrency.format(leaseCost.balanceUsd)} | ${leaseCost.balanceAkt} AKT`,
               },
             ]);
           }


### PR DESCRIPTION
This PR is related to #109 and fixes the cost display on the deployment page. The old function `getAvgCostPerMonth` returned the price per month in USD but was used as AKT amount.
Thats why i changed the function to `getAvgAktCostPerMonth` and removed the price param because you can easily calculate the USD value with the returned value * price.