### PR TITLE
fix: broken cert gen on preflight

### DIFF
--- a/web/src/api/mutations.ts
+++ b/web/src/api/mutations.ts
@@ -60,6 +60,17 @@ export const createCertificate = async () => {
   return mutateMethod(rpcNode, wallet);
 };
 
+export const revokeCertificate = async (certificate: string) => {
+  const { rpcNode, networkType } = getRpcNode();
+  const wallet = await getKeplr();
+
+  const mutateMethod = networkType === 'testnet'
+    ? beta3.certificates.broadcastRevokeCertificate
+    : beta2.certificates.broadcastRevokeCertificate;
+
+  return mutateMethod(rpcNode, wallet, certificate);
+};
+
 export const createLease = async (bidId: {
   owner: string;
   dseq: Long;

--- a/web/src/api/rpc/beta2/certificates.tsx
+++ b/web/src/api/rpc/beta2/certificates.tsx
@@ -157,7 +157,9 @@ export const saveCertificate = (walletId: string, certificate: any) => {
 
   localStorage.setItem('certificates', JSON.stringify(marshaledCerts));
 
-  return marshaledCerts.findIndex((cert) => cert.hash === hash);
+  // reload the certificate list to ensure the index is correct
+  const certList = loadCertificates(walletId);
+  return certList.findIndex((cert) => cert.hash === hash);
 };
 
 // Returns a list of the public keys for all available certificates

--- a/web/src/components/DeploymentStepper/index.tsx
+++ b/web/src/components/DeploymentStepper/index.tsx
@@ -116,10 +116,6 @@ const DeploymentStepper: React.FC<DeploymentStepperProps> = () => {
         // if that's the case, used the stored version
         const cachedDetails = JSON.parse(localStorage.getItem(`${lease?.leaseId?.dseq}`) || '');
         const _sdl = sdl ? sdl : cachedDetails.sdl;
-      
-        const sendManifest = networkType === 'testnet'
-          ? sendManifestBeta2
-          : sendManifestBeta3;
 
         if (lease) {
           mxSendManifest({ address: keplr.accounts[0].address, lease, sdl: _sdl}, {


### PR DESCRIPTION
Fixes an issue on the preflight where the active ID was being set incorrectly have creating the cert. Also fixes a bug where revoke wasn't working with testnet.
