### PR TITLE
fix: silent failure when deploying to testnet

### DIFF
--- a/web/src/api/rpc/beta3/deployments.tsx
+++ b/web/src/api/rpc/beta3/deployments.tsx
@@ -291,13 +291,6 @@ export async function createDeployment(
     return Promise.reject('Unable to initialize signing client');
   }
 
-  // If the SDL does not have a GPU resource set, set it to 0
-  // to avoid a bug in the backend
-  for (const service of Object.keys(sdl.services)) {
-    const profile = sdl.profiles.compute[service];
-    profile.resources.gpu = profile.resources.gpu || 0;
-  }
-
   const client = await getMsgClient(rpcNode, signer);
   const groups = DeploymentGroups(sdl, 'beta3');
   const ver = await ManifestVersion(sdl, 'beta3');


### PR DESCRIPTION
Fixes a bug where an old workaround for the GPU field was causing a crash when attempting to create the deployment. Removes the old work around as it's no longer needed (akashjs takes care of adding the field).
