### PR TITLE
fix: some pages in deployment flow flashing old-content

### DIFF
--- a/web/.eslintrc.yml
+++ b/web/.eslintrc.yml
@@ -4,7 +4,6 @@ env:
 extends:
   - eslint:recommended
   - plugin:@typescript-eslint/recommended
-  - plugin:react/recommended
 overrides: []
 parser: '@typescript-eslint/parser'
 parserOptions:

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4,11 +4,13 @@ import { BrowserRouter as Router, Route, Routes, useNavigate } from 'react-route
 import SideNav from './components/SideNav';
 import Keplr from './components/KeplrLogin';
 import Logging from './components/Logging';
+import Stack from '@mui/material/Stack';
 import { useRecoilState } from 'recoil';
 import { activeCertificate, keplrState } from './recoil/atoms';
 import { getKeplr } from './_helpers/keplr-utils';
 import { loadActiveCertificate } from './recoil/api';
 import { useWallet } from './hooks/useWallet';
+import Loading from './components/Loading';
 
 // Lazy loading all pages in appropriate time
 const DeploymentStepper = lazy(() => import('./components/DeploymentStepper'));
@@ -115,7 +117,11 @@ export default function App() {
 
   return (
     <Logging>
-      <Suspense fallback={<div>Loading...</div>}>
+      <Suspense fallback={
+        <Stack direction="column">
+          <Loading title="Loading" />
+        </Stack>
+      }>
         <Keplr>
           <AppRouter />
         </Keplr>

--- a/web/src/api/rpc/beta2/deployments.tsx
+++ b/web/src/api/rpc/beta2/deployments.tsx
@@ -399,6 +399,8 @@ export async function sendManifest(address: string, lease: Lease, sdl: any) {
   const providerFetch = mtlsFetch(cert, provider.provider.hostUri);
   const manifest = Manifest(sdl, 'beta2', true);
 
+  console.log(manifest);
+
   let jsonStr = JSON.stringify(manifest);
 
   jsonStr = jsonStr.replaceAll('"quantity":{"val', '"size":{"val');

--- a/web/src/api/rpc/beta2/deployments.tsx
+++ b/web/src/api/rpc/beta2/deployments.tsx
@@ -420,10 +420,10 @@ export async function sendManifest(address: string, lease: Lease, sdl: any) {
         }
 
         if (retry > 0) {
-          logging.warn('Sending manifest failed. Retrying...');
+          // logging.warn('Sending manifest failed. Retrying...');
           setTimeout(() => attemptSend(retry - 1), 1000);
         } else {
-          logging.warn('Sending manifest failed.');
+          // logging.warn('Sending manifest failed.');
           result.text().then(reject);
         }
       });

--- a/web/src/api/rpc/beta3/deployments.tsx
+++ b/web/src/api/rpc/beta3/deployments.tsx
@@ -412,10 +412,10 @@ export async function sendManifest(address: string, lease: Lease, sdl: any) {
         }
 
         if (retry > 0) {
-          logging.warn('Sending manifest failed. Retrying...');
+          // logging.warn('Sending manifest failed. Retrying...');
           setTimeout(() => attemptSend(retry - 1), 1000);
         } else {
-          logging.warn('Sending manifest failed.');
+          // logging.warn('Sending manifest failed.');
           result.text().then(reject);
         }
       });

--- a/web/src/components/SideNav/index.tsx
+++ b/web/src/components/SideNav/index.tsx
@@ -21,6 +21,7 @@ import { useWallet } from '../../hooks/useWallet';
 import { HelpCenterSideHelp } from '../../components/HelpCenter/HelpCenterSideHelp';
 import { showKeplrWindow } from '../../recoil/atoms';
 import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
+import Loading from '../Loading';
 
 export default function SideNav(props: any) {
   const { children } = props;
@@ -71,7 +72,7 @@ export default function SideNav(props: any) {
   };
 
   return (
-    <Box sx={{ display: 'flex' }}>
+    <Stack>
       <AppBar position="fixed" open={open} color="default">
         <Toolbar>
           <IconButton
@@ -142,7 +143,7 @@ export default function SideNav(props: any) {
             paddingX="10px"
             paddingY="10px"
           >
-            <Link to="landing/node-deployment" id="link_new_deployment" className="block_default_hover">
+            <Link to="landing/node-deployment" id="link_new_deployment">
               <SideNavMenuItemRed>
                 <AddIcon style={{ color: '#F43F5E' }} />
                 <SideNavMenuItemLabel style={{ color: '#F43F5E' }}>
@@ -178,7 +179,7 @@ export default function SideNav(props: any) {
               </SideNavMenuItem>
             </NavLink>
 
-            <SideNavMenuItem>
+            <SideNavMenuItem id='link_help'>
               <IconWrapper onClick={toggleHelpCenter}>
                 <Icon type="help" />
               </IconWrapper>
@@ -186,11 +187,10 @@ export default function SideNav(props: any) {
             </SideNavMenuItem>
 
             <Typography
-              style={{ marginLeft: 'auto' }}
               variant="caption"
               component="p"
               color="red"
-              mt={'auto'}
+              marginTop="0.5rem"
             >
               {`v${version}`}
             </Typography>
@@ -198,10 +198,12 @@ export default function SideNav(props: any) {
         </Suspense>
       </Drawer>
       <Box component="main" sx={{ flexGrow: 1, p: 3 }}>
-        {children}
+        <Suspense fallback={<Loading />}>
+          {children}
+        </Suspense>
       </Box>
       <HelpCenterSideHelp isOpen={isHelpCenterOpen} onClose={toggleHelpCenter} />
-    </Box>
+    </Stack>
   );
 }
 
@@ -302,6 +304,7 @@ const SideNavMenuItemRed = styled(SideNavMenuItem)`
   padding-left: 8px;
   border-radius: 8px;
   border: 1px solid #ffffff;
+
   &:hover {
     border: 1px solid #fa5757;
     background: #fff1f2;

--- a/web/src/style/app.css
+++ b/web/src/style/app.css
@@ -702,10 +702,6 @@ video {
   height: 3rem;
 }
 
-.h-full {
-  height: 100%;
-}
-
 .w-\[106px\] {
   width: 106px;
 }
@@ -765,10 +761,6 @@ video {
 
 .justify-between {
   justify-content: space-between;
-}
-
-.gap-4 {
-  gap: 1rem;
 }
 
 .gap-2 {
@@ -858,10 +850,6 @@ video {
 
 .pl-4 {
   padding-left: 1rem;
-}
-
-.text-left {
-  text-align: left;
 }
 
 .text-center {
@@ -1272,21 +1260,13 @@ a {
   margin-top: 4px;
   border-radius: 8px;
   border: 1px solid transparent;
+  background-color: #ffffff;
 }
 
-#link_new_deployment:hover,
 #link_my_deployments:hover,
 #link_settings:hover,
 #link_help:hover {
   border: 1px solid #f0f1f4;
-}
-
-.block_default_hover:hover {
-  border: none !important;
-}
-
-#link_help {
-  margin-bottom: 24px;
 }
 
 #button_close_side_nav:hover * {

--- a/web/src/style/app.scss
+++ b/web/src/style/app.scss
@@ -252,20 +252,13 @@ a {
     margin-top: 4px;
     border-radius: 8px;
     border: 1px solid transparent;
+    background-color: #ffffff;
 }
 
-#link_new_deployment:hover,
 #link_my_deployments:hover,
 #link_settings:hover,
 #link_help:hover {
     border: 1px solid #f0f1f4;
-}
-.block_default_hover:hover {
-    border: none !important;
-}
-
-#link_help {
-    margin-bottom: 24px;
 }
 
 #button_close_side_nav:hover * {


### PR DESCRIPTION
Fixes some issues where, during the deployment flow, after the progress bar closes the old page would be displayed for a short time before advancing to the next stage.
