### PR TITLE
fix: catch exception when lease status is unavailable

### DIFF
--- a/web/src/hooks/useDeploymentData.ts
+++ b/web/src/hooks/useDeploymentData.ts
@@ -72,7 +72,11 @@ export default function useDeploymentData(owner: string) {
         // monkey patch the leaseId to avoid [object Object]
         lease.leaseId.dseq = Long.fromValue(lease.leaseId.dseq);
 
-        return providerUrl && queryLeaseStatus(LeaseID.toJSON(lease.leaseId) as any, providerUrl);
+        try {
+          return providerUrl && queryLeaseStatus(LeaseID.toJSON(lease.leaseId) as any, providerUrl);
+        } catch (e) {
+          console.warn('Unable to fetch lease status', e);
+        }
       }
     },
     [certificate]
@@ -131,12 +135,12 @@ export default function useDeploymentData(owner: string) {
           }
 
           if (query.deployment?.state === 1) {
-            const status = await getLeaseStatus(lease);
+            try {
+              const status = await getLeaseStatus(lease);
 
-            if (status === undefined || status === '') {
-              console.warn('Unable to resolve lease status for deployment:', dseq);
-            } else {
-              try {
+              if (status === undefined || status === '') {
+                console.warn('Unable to resolve lease status for deployment:', dseq);
+              } else {
                 const leaseStatus = await status.json() as any;
 
                 if (leaseStatus && leaseStatus.services) {
@@ -146,9 +150,9 @@ export default function useDeploymentData(owner: string) {
                     .map((uri) => uri[0])
                     .join(', ');
                 }
-              } catch (e) {
-                console.warn('Unable to parse lease status', e);
               }
+            } catch (e) {
+              console.warn('Unable to resolve lease status for deployment:', dseq);
             }
           }
 

--- a/web/src/hooks/useLeaseStatus.ts
+++ b/web/src/hooks/useLeaseStatus.ts
@@ -38,7 +38,11 @@ export function useLeaseStatus(lease: Lease) {
     if (hostUri && leaseId && certificate.$type !== 'Invalid Certificate') {
       return queryLeaseStatus(LeaseID.toJSON(leaseId) as any, hostUri)
         .then(response => response.json())
-        .then(response => response as LeaseStatus);
+        .then(response => response as LeaseStatus)
+        .catch(err => {
+          console.warn('Error fetching lease status', err);
+          return undefined;
+        });
     }
 
     return Promise.reject('No lease status available');


### PR DESCRIPTION
FIx a possible exception on the list page if a deployment can't be looked up for some reason.
